### PR TITLE
Add link to main site in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Ploopy Trackball
+# [The Ploopy Trackball](https://www.ploopy.co/)
 
 By some stroke of luck, you've made your way here. The Ploopy Trackball. Your life will never be the same.
 


### PR DESCRIPTION
I discovered this project through github, but I couldn't tell where to find actual information about the trackball. I linked the site so people can find more introductory information about the actual trackball instead of the firmware source or blueprints.